### PR TITLE
[CW: Touches ProfanityList.cs] Remove "Lesbian" and "Lesbians"

### DIFF
--- a/ProfanityFilter/ProfanityFilter/ProfanityList.cs
+++ b/ProfanityFilter/ProfanityFilter/ProfanityList.cs
@@ -969,8 +969,6 @@ namespace ProfanityFilter
              "lemon party",
              "LEN",
              "leper",
-             "lesbian",
-             "lesbians",
              "lesbo",
              "lesbos",
              "lez",


### PR DESCRIPTION
These are sexualities, and should not be considered profane