### PR TITLE
Fix case insensitivity in ContainsProfanity

### DIFF
--- a/ProfanityFilter.Tests.Unit/ProfanityTests.cs
+++ b/ProfanityFilter.Tests.Unit/ProfanityTests.cs
@@ -898,5 +898,14 @@ namespace ProfanityFilter.Tests.Unit
 
             Assert.IsTrue(result);
         }
+
+        [TestMethod]
+        public void ContainsProfanityReturnsTrueWhenProfanityIsVariableCase()
+        {
+            var filter = new ProfanityFilter();
+            var result = filter.ContainsProfanity("Fuck");
+
+            Assert.IsTrue(result);
+        }
     }
 }

--- a/ProfanityFilter/ProfanityFilter/ProfanityFilter.cs
+++ b/ProfanityFilter/ProfanityFilter/ProfanityFilter.cs
@@ -272,9 +272,9 @@ namespace ProfanityFilter
                 return false;
             }
 
-            Regex regex = new Regex(string.Format(@"(?:{0})", string.Join("|", potentialProfanities).Replace("$", "\\$"), RegexOptions.IgnoreCase));
+            string regexPattern = string.Format(@"(?:{0})", string.Join("|", potentialProfanities).Replace("$", "\\$"));
 
-            foreach (Match profanity in regex.Matches(term))
+            foreach (Match profanity in Regex.Matches(term, regexPattern, RegexOptions.IgnoreCase))
             {
                 // if any matches are found and aren't in the allowed list, we can return true here without checking further
                 if (!AllowList.Contains(profanity.Value.ToLower(CultureInfo.InvariantCulture)))


### PR DESCRIPTION
ContainsProfanity case insensitivity does not work because RegexOptions.IgnoreCase does not apply when used to create a Regex object.  This change fixes it by adding the option to the call to Regex.Matches instead.