### PR TITLE
Fixed ContainsProfanity regex CTOR to ignore character casing

### DIFF
--- a/ProfanityFilter.Tests.Unit/ProfanityTests.cs
+++ b/ProfanityFilter.Tests.Unit/ProfanityTests.cs
@@ -898,5 +898,17 @@ namespace ProfanityFilter.Tests.Unit
 
             Assert.IsTrue(result);
         }
+
+        [TestMethod]
+        [DataRow("ASS")]
+        [DataRow("Ass")]
+        [DataRow("A$$")]
+        public void ContainsProfanityReturnsTrueForWordsWithUppercase(string input)
+        {
+            var filter = new ProfanityFilter();
+            var result = filter.ContainsProfanity(input);
+
+            Assert.IsTrue(result);
+        }
     }
 }

--- a/ProfanityFilter/ProfanityFilter/ProfanityFilter.cs
+++ b/ProfanityFilter/ProfanityFilter/ProfanityFilter.cs
@@ -272,7 +272,7 @@ namespace ProfanityFilter
                 return false;
             }
 
-            Regex regex = new Regex(string.Format(@"(?:{0})", string.Join("|", potentialProfanities).Replace("$", "\\$"), RegexOptions.IgnoreCase));
+            Regex regex = new Regex(string.Format(@"(?:{0})", string.Join("|", potentialProfanities).Replace("$", "\\$")), RegexOptions.IgnoreCase);
 
             foreach (Match profanity in regex.Matches(term))
             {


### PR DESCRIPTION
RegexOptions.IgnoreCase was being included in the String.Format instead of the Regex CTOR.  Also included a test to verify ContainsProfanity works with uppercase characters.